### PR TITLE
Make the polka-java library available in the central Maven repository for easy integration.

### DIFF
--- a/packages/build.gradle
+++ b/packages/build.gradle
@@ -7,6 +7,8 @@ plugins {
     id('signing')
 }
 
+// FIXME: For the origin project, something like io.github.polkadot-java would be a suitable group name
+// which has to be registered with the central OOSRH (sonatype org)
 group = "net.cloudburo"
 archivesBaseName = "polkadot-java"
 version '1.0-SNAPSHOT'
@@ -133,6 +135,7 @@ uploadArchives {
                 name 'Java Substrate Client Library'
                 packaging 'jar'
                 // optionally artifactId can be defined here
+                // FIXME: Decscription to be adjusted 
                 description 'Java Polkadot API, this is a clone of https://github.com/polkadot-java/api'
                 url 'https://cloudburo.net'
 
@@ -148,7 +151,8 @@ uploadArchives {
                         url 'https://www.gnu.org/licenses/gpl-3.0.html'
                     }
                 }
-
+                
+                // FIXME: Adjust developer to the one supporting the initial library
                 developers {
                     developer {
                         id 'felix'

--- a/packages/build.gradle
+++ b/packages/build.gradle
@@ -4,10 +4,11 @@ plugins {
     id('idea')
     id('eclipse')
     id('application')
-
+    id('signing')
 }
 
-group 'polkadot-java'
+group = "net.cloudburo"
+archivesBaseName = "polkadot-java"
 version '1.0-SNAPSHOT'
 
 sourceCompatibility = 1.8
@@ -23,7 +24,7 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 
-
+        
 dependencies {
     compile fileTree(dir: 'libs', includes: ['*jar'])
 
@@ -90,3 +91,80 @@ dependencies {
 
 }
 
+javadoc {
+    options.addBooleanOption('Xdoclint:none', true )
+}
+
+tasks {
+
+    task javadocJar(type: Jar) {
+        classifier = 'javadoc'
+        from javadoc
+    }
+    task sourcesJar(type: Jar) {
+        classifier = 'sources'
+        from sourceSets.main.allSource
+    }
+}
+
+// javadoc removed
+artifacts {
+    archives  javadocJar,sourcesJar
+}
+
+signing {
+    sign configurations.archives
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            pom.project {
+                name 'Java Substrate Client Library'
+                packaging 'jar'
+                // optionally artifactId can be defined here
+                description 'Java Polkadot API, this is a clone of https://github.com/polkadot-java/api'
+                url 'https://cloudburo.net'
+
+                scm {
+                    connection 'scm:git:https://github.com/cloudburo/api'
+                    developerConnection 'scm:git:https://github.com/cloudburo/api'
+                    url 'https://github.com/cloudburo/api'
+                }
+
+                licenses {
+                    license {
+                        name 'GNU Public Licences, Version 3.0'
+                        url 'https://www.gnu.org/licenses/gpl-3.0.html'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'felix'
+                        name 'Felix Kuestahler'
+                        email 'support@cloudburo.net'
+                    }
+                    developer {
+                        id 'security'
+                        name 'SecurityIssueReporting'
+                        organizationUrl 'https://hackerone.com/central-security-project'
+                        roles {
+                                role  'security'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The following gradle enhancements would allow to populate the library into the central Maven repository and enable it for easy consumption by developers.
I did a test run using a clone and successfully deployed a "0.1" version, which is representing the actual 1.0.0-SNAPSHOT version under my group name `net.cloudburo`. It can be found under: [https://search.maven.org/search?q=a:polkadot-java](https://search.maven.org/search?q=a:polkadot-java).
I could now start, writing a simple hello world project, referencing the library, refer to gradle, which is now straightforward  [Github clb-polkadot-java-hello-world](https://github.com/cloudburo/clb-polkadot-java-hello-world/blob/master/build.gradle).
It would beneficial if that global maven repository would hold a "official" version of this project.
In order to enable that, this project would have to ensure the following pre-requisite, as outlined in the [Sonatype OSSRH Guide](https://central.sonatype.org/pages/ossrh-guide.html)

- Create a user account with Sonatype (which gets you an `ossrhUsername` and `ossrhPassword`)
- Decide for a valid group name, i.e. `io.github.polkad-java`
- Have a valid PGP key in order to sign the delpoyed jar

Additional some descriptions and variables in the gradle would have to be adjusted (refer to the FIXME in the gradle). 

With that the library could be deployed officially and I could remove my cloned one.